### PR TITLE
Time zone issues

### DIFF
--- a/demo/GraphTutorial/Models/CalendarViewModel.cs
+++ b/demo/GraphTutorial/Models/CalendarViewModel.cs
@@ -12,6 +12,7 @@ namespace GraphTutorial.Models
     public class CalendarViewModel
     {
         private DateTime _startOfWeek;
+        private DateTime _endOfWeek;
         private List<CalendarViewEvent> _events;
 
         public CalendarViewModel()
@@ -23,6 +24,7 @@ namespace GraphTutorial.Models
         public CalendarViewModel(DateTime startOfWeek, IEnumerable<Event> events)
         {
             _startOfWeek = startOfWeek;
+            _endOfWeek = startOfWeek.AddDays(7);
             _events = new List<CalendarViewEvent>();
 
             if (events != null)
@@ -114,7 +116,10 @@ namespace GraphTutorial.Models
 
         private IEnumerable<CalendarViewEvent> GetEventsForDay(System.DayOfWeek day)
         {
-            return _events.Where(e => e.Start.DayOfWeek.Equals(day));
+            return _events.Where(e => (e.End > _startOfWeek &&
+                ((e.Start.DayOfWeek.Equals(day) && e.Start >= _startOfWeek) ||
+                 (e.End.DayOfWeek.Equals(day) && e.End < _endOfWeek))));
+
         }
     }
 }

--- a/demo/GraphTutorial/Views/Calendar/_DailyEventsPartial.cshtml
+++ b/demo/GraphTutorial/Views/Calendar/_DailyEventsPartial.cshtml
@@ -39,6 +39,14 @@
     }
     <td class="calendar-view-timespan">
       <div>@item.Start.ToString(timeFormat) - @item.End.ToString(timeFormat)</div>
+      @if (item.Start.Date != Model.Day.Date)
+      {
+        <div class="calendar-view-date-diff">Start date: @item.Start.Date.ToShortDateString()</div>
+      }
+      @if (item.End.Date != Model.Day.Date)
+      {
+        <div class="calendar-view-date-diff">End date: @item.End.Date.ToShortDateString()</div>
+      }
     </td>
     <td>
       <div class="calendar-view-subject">@item.Subject</div>

--- a/demo/GraphTutorial/wwwroot/css/site.css
+++ b/demo/GraphTutorial/wwwroot/css/site.css
@@ -107,4 +107,8 @@ body {
 .calendar-view-organizer {
   font-size: .75em;
 }
+
+.calendar-view-date-diff {
+  font-size: .75em
+}
 /* </CssSnippet> */


### PR DESCRIPTION
UI fixes caused by time zone issues

- Passed start of week in user's time zone to the CalendarViewModel (rather than start in UTC). This was causing the view model to shift the start to the wrong day for time zones greater than UTC.
- Improved the LINQ query for getting events for a particular day of the week to account for events that span multiple days.
- Added UI message indicating when a start or end date is different than the day an event shows up on.

Fixes #7 
Fixes #14